### PR TITLE
Update certificate download URL in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ if [ "$PROXY_USE_SSL" = "true" ]; then
 
   if [ -z "$(ls -A $CERTS_DIR)" ]; then
     echo "Downloading localhost.direct certificates..."
-    curl -o certs.zip -LOs https://aka.re/localhost
+    curl -o certs.zip -LOs https://aka.re/localhost-ss
     unzip -P localhost certs.zip
     rm certs.zip
     mv localhost.direct.* $CERTS_DIR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,11 +48,11 @@ fi
 PROXY_FORCE_HTTPS=${PROXY_FORCE_HTTPS,,}
 
 if [ -z "$PROXY_SSL_CERT_NAME" ]; then
-  PROXY_SSL_CERT_NAME="localhost.direct.crt"
+  PROXY_SSL_CERT_NAME="localhost.direct.SS.crt"
 fi
 
 if [ -z "$PROXY_SSL_KEY_NAME" ]; then
-  PROXY_SSL_KEY_NAME="localhost.direct.key"
+  PROXY_SSL_KEY_NAME="localhost.direct.SS.key"
 fi
 
 if [ -z "$ADD_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN" ]; then


### PR DESCRIPTION
They have have updated a non-public option for CA Bundles. Look [here](https://github.com/Upinel/localhost.direct?tab=readme-ov-file#a-non-public-ca-certificate-if-you-have-admin-right-on-your-development-environment-you-can-use-the-following-10-years-long-pre-generated-self-signed-certificate).
